### PR TITLE
Please review topic branch 'users/brigadir/ticket.30'

### DIFF
--- a/cpp/solution/properties/cl command line.props
+++ b/cpp/solution/properties/cl command line.props
@@ -114,7 +114,7 @@
       <!-- Debug -->
       <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
       <!-- Code generation -->
-      <AdditionalOptions>/RTCc /RTC1 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/RTC1 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
 
     <!-- Linker options -->

--- a/cpp/source/arborgvt/graph/graph.cpp
+++ b/cpp/source/arborgvt/graph/graph.cpp
@@ -287,7 +287,7 @@ vertex* __vectorcall graph::addVertex(_In_ STLADD string_type&& name, _In_ const
      *
      * // For MSVC 2015 Update 2 and above:
      * std::pair<vertices_cont_t::iterator, bool> result =
-     *     m_vertices.insert({name, vertex {std::move(name), coordinates}});
+     *     m_vertices.insert({STLADD string_type {name}, vertex {std::move(name), coordinates}});
      *
      * Thus, the above code for 'VC 2015 Update 2' calls this template ctor of `std::pair`:
      * std::pair(std::basic_string<...>& _Val1, arbor::vertex&& _Val2 = {...});
@@ -297,9 +297,8 @@ vertex* __vectorcall graph::addVertex(_In_ STLADD string_type&& name, _In_ const
      * Following [8.5.4.4] the code, at first, makes a copy of `name` argument (passing it as `_Val1` parameter),
      * and after that the code moves `name` into `vertex` ctor.
      */
-    STLADD string_type key {name};
     std::pair<vertices_cont_t::iterator, bool> result =
-        m_vertices.emplace(key, vertex {std::move(name), coordinates});
+        m_vertices.insert({STLADD string_type {name}, vertex {std::move(name), coordinates}});
     return &(result.first->second);
 }
 

--- a/cpp/source/arborgvt/graph/graph.h
+++ b/cpp/source/arborgvt/graph/graph.h
@@ -35,6 +35,26 @@ ARBOR_BEGIN
  * Public versions of `addEdge` and `addVertex` methods ain't used by this class and are exposed as public interface
  * only.
  */
+class graph_settings
+{
+protected:
+    static constexpr float m_stiffness = 750.0f;
+#if defined(__ICL)
+    // Intel C++ 16.0 doesn't support single-quotation mark as a digit separator for floating point types,
+    // it's a known bug with internal tracker DPD200379927.
+    static constexpr float m_repulsion = 10000.0f;
+#else
+    static constexpr float m_repulsion = 10'000.0f;
+#endif
+    static constexpr float m_friction = 0.1f;
+    static constexpr float m_animationStep = 0.04f;
+    static constexpr float m_timeSlice = 0.01f;
+    static constexpr float m_energyThreshold = 0.7f;
+    static constexpr float m_theta = 0.4f;
+    static constexpr bool m_gravity = false;
+    static constexpr bool m_autoStop = false;
+};
+
 class graph_data_type
 {
 protected:
@@ -131,7 +151,7 @@ protected:
     };
 };
 
-class graph: private graph_data_type
+class __declspec(empty_bases) graph: private graph_data_type, private graph_settings
 {
 public:
     typedef data_iterator<vertices_cont_t::mapped_type, vertices_cont_t::iterator> vertices_iterator;
@@ -266,22 +286,6 @@ private:
     void applyBarnesHutRepulsion();
     void applySprings();
     void __fastcall updateVelocityAndPosition(_In_ const float time);
-
-    static constexpr float m_stiffness = 750.0f;
-#if defined(__ICL)
-    // Intel C++ 16.0 doesn't support single-quotation mark as a digit separator for floating point types,
-    // it's a known bug with internal tracker DPD200379927.
-    static constexpr float m_repulsion = 10000.0f;
-#else
-    static constexpr float m_repulsion = 10'000.0f;
-#endif
-    static constexpr float m_friction = 0.1f;
-    static constexpr float m_animationStep = 0.04f;
-    static constexpr float m_timeSlice = 0.01f;
-    static constexpr float m_energyThreshold = 0.7f;
-    static constexpr float m_theta = 0.4f;
-    static constexpr bool m_gravity = false;
-    static constexpr bool m_autoStop = false;
 
     /*
      * `m_graphBound` is the area used by Barnes Hut algorithm. This is a coordinate space where all graph vertices


### PR DESCRIPTION
The code now uses Empty Base Class Optimization (EBCO), implemented in
VC 2015.2.

I removed /RTCc switch from the command line because it produced
warnings on standard libraries.

**But now** (not after changes made by this commit, but after upgrading
MSFT VS 2015 from Update 1 to Update 2) **Intel C++ compiler can't
compile CRT libraries**. For more information see this topic:
https://software.intel.com/en-us/forums/intel-c-compiler/topic/623368.

**Therefore, it's impossible to build the code with ICC until ICC 16.0
Update 3 release**. :imp: 

Resloves: #30 
