### PR TITLE
Please review topic branch 'users/brigadir/optimization-proposed'

### DIFF
--- a/ArborGVT/src/BarnesHutTree.cs
+++ b/ArborGVT/src/BarnesHutTree.cs
@@ -44,7 +44,7 @@ namespace ArborGVT
 
         public BarnesHutTree(ArborPoint origin, ArborPoint h, double dist)
         {
-            this.fDist = dist;
+            this.fDist = dist * dist;
             this.fRoot = new Branch(origin, h.sub(origin));
         }
 
@@ -173,11 +173,11 @@ namespace ArborGVT
                         ptx = node.Pt;
 
                         k = m.Pt.sub(ptx);
-                        kMag = k.magnitude();
+                        kMag = k.magnitudeSquare();
 
-                        l = Math.Max(1, kMag);
                         i = ((kMag > 0) ? k : ArborPoint.newRnd(1)).normalize();
-                        m.applyForce(i.mul(g * massx).div(l * l));
+                        l = Math.Max(1, kMag);
+                        m.applyForce(i.mul(g * massx).div(l));
                     }
                     else
                     {
@@ -186,9 +186,9 @@ namespace ArborGVT
                         ptx = branch.Pt.div(massx);
 
                         k = m.Pt.sub(ptx);
-                        kMag = k.magnitude();
+                        kMag = k.magnitudeSquare();
 
-                        double h = Math.Sqrt(branch.Size.X * branch.Size.Y);
+                        double h = branch.Size.X * branch.Size.Y;
                         if (h / kMag > fDist)
                         {
                             f.Enqueue(branch.Q[QNe]);
@@ -198,9 +198,9 @@ namespace ArborGVT
                         }
                         else
                         {
-                            l = Math.Max(1, kMag);
                             i = ((kMag > 0) ? k : ArborPoint.newRnd(1)).normalize();
-                            m.applyForce(i.mul(g * massx).div(l * l));
+                            l = Math.Max(1, kMag);
+                            m.applyForce(i.mul(g * massx).div(l));
                         }
                     }
                 }

--- a/cpp/source/arborgvt/barnhut/barnhut.h
+++ b/cpp/source/arborgvt/barnhut/barnhut.h
@@ -12,7 +12,7 @@ public:
     barnes_hut_tree(_In_ __m128 area, _In_ const float dist)
         :
         m_root {std::make_unique<branch>(area)},
-        m_dist {dist}
+        m_dist {dist * dist}
     {
     }
 

--- a/cpp/source/arborgvt/barnhut/bhutquad.cpp
+++ b/cpp/source/arborgvt/barnhut/bhutquad.cpp
@@ -101,9 +101,13 @@ void branch::applyForce(
                 temp2 = _mm_mul_ps(temp, temp);
                 temp2 = _mm_add_ps(temp2, _mm_shuffle_ps(temp2, temp2, 0b10110001));
             }
-            temp2 = _mm_sqrt_ps(temp2);
+            temp2 = _mm_rsqrt_ps(temp2);
         }
-        temp = _mm_mul_ps(temp, _mm_rcp_ps(temp2));
+        else
+        {
+            temp2 = _mm_rcp_ps(temp2);
+        }
+        temp = _mm_mul_ps(temp, temp2);
         value.data[0] = repulsion;
         temp2 = _mm_load_ps(value.data);
         temp2 = _mm_shuffle_ps(temp2, temp2, 0);

--- a/cpp/source/arborgvt/barnhut/bhutquad.cpp
+++ b/cpp/source/arborgvt/barnhut/bhutquad.cpp
@@ -69,11 +69,8 @@ void branch::applyForce(
         temp2 = _mm_mul_ps(temp2, temp2);
         temp2 = _mm_add_ps(temp2, _mm_shuffle_ps(temp2, temp2, 0b10110001));
     }
-    __m128 dotProduct = temp2;
-    temp2 = _mm_sqrt_ps(temp2);
     __m128 temp3 = _mm_sub_ps(_mm_shuffle_ps(m_area, m_area, 0b01001110), m_area);
     temp3 = _mm_mul_ps(temp3, _mm_shuffle_ps(temp3, temp3, 0b10110001));
-    temp3 = _mm_sqrt_ps(temp3);
     temp3 = _mm_mul_ps(temp3, _mm_rcp_ps(temp2));
     sse_t value;
     value.data[0] = dist;
@@ -91,7 +88,7 @@ void branch::applyForce(
         value.data[0] = 1.0f;
         temp3 = _mm_load_ps(value.data);
         temp3 = _mm_shuffle_ps(temp3, temp3, 0);
-        temp3 = _mm_max_ps(dotProduct, temp3);
+        temp3 = _mm_max_ps(temp2, temp3);
         if (0b1111 & _mm_movemask_ps(_mm_cmpeq_ps(temp2, ARBOR getZeroVector())))
         {
             temp = ARBOR randomVector(1.0f);

--- a/cpp/source/arborgvt/graph/graph.cpp
+++ b/cpp/source/arborgvt/graph/graph.cpp
@@ -536,9 +536,13 @@ void graph::applySprings()
                 temp2 = _mm_mul_ps(temp, temp);
                 temp2 = _mm_add_ps(temp2, _mm_shuffle_ps(temp2, temp2, 0b10110001));
             }
-            temp2 = _mm_sqrt_ps(temp2);
+            temp2 = _mm_rsqrt_ps(temp2);
         }
-        temp = _mm_mul_ps(temp, _mm_rcp_ps(temp2));
+        else
+        {
+            temp2 = _mm_rcp_ps(temp2);
+        }
+        temp = _mm_mul_ps(temp, temp2);
         sse_t value;
         value.data[0] = (*it)->getLength();
         temp2 = _mm_load_ps(value.data);


### PR DESCRIPTION
- Remove `SQRTPS`s from `BHUT branch::applyForce`
  
  I removed two `SQRTPS` instructions from `BHUT branch::applyForce` -- I
  could safely execute without them.
  
  See also: #22
- Replace `RCPPS` + `SQRTPS` with `RSQRTPS`
  
  I replaced `RCPPS` + `SQRTPS` paired instructions with one `RSQRTPS`.
  This gives **HUGE** performance boost!
  
  See also: #22
- Remove SQRT and MUL ops from C# code
  
  Code in `ArborGVT::BarnesHutTree::applyForces` method get optimized. See d95d5a9 for more details.
